### PR TITLE
If there is no domain after `@` it should return false

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = function(value) {
   }
   // It must contain an '@' somewhere in the middle.
   var atPos = value.indexOf('@')
-  if (atPos === -1 || atPos === 0 || atPos === value.length) {
+  if (atPos === -1 || atPos === 0 || atPos === value.length - 1) {
     return false
   }
   var username = value.substring(0, atPos)


### PR DESCRIPTION
This ensures when there is no chars after `@` symbol
validation return false. Currrently it would bypass for loop since
the domain string is empty and the function would return true.